### PR TITLE
fix db migrations in which original column was third_thursday_talk in…

### DIFF
--- a/db/migrate/20160415054550_rename_column_artist_talk_titlein_showsto_third_thursday_talk_title.rb
+++ b/db/migrate/20160415054550_rename_column_artist_talk_titlein_showsto_third_thursday_talk_title.rb
@@ -1,5 +1,5 @@
 class RenameColumnArtistTalkTitleinShowstoThirdThursdayTalkTitle < ActiveRecord::Migration
   def change
-  	rename_column :shows, :third_thursday_talk_title, :third_thursday_talk_title
+  	rename_column :shows, :artist_talk_title, :third_thursday_talk_title
   end
 end

--- a/db/migrate/20160415054637_rename_column_artist_talk_datein_showsto_third_thursday_talk_date.rb
+++ b/db/migrate/20160415054637_rename_column_artist_talk_datein_showsto_third_thursday_talk_date.rb
@@ -1,5 +1,5 @@
 class RenameColumnArtistTalkDateinShowstoThirdThursdayTalkDate < ActiveRecord::Migration
   def change
-  	  	rename_column :shows, :third_thursday_talk_date, :third_thursday_talk_date
+  	  	rename_column :shows, :artist_talk_date, :third_thursday_talk_date
   end
 end


### PR DESCRIPTION
…stead of artist_talk. Error was caused by a global change. This change has been tested locally and under heroku