### PR TITLE
Migration and addition of Active Storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ public/system
 
 latest.dump
 .env
+
+storage/

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
+require "active_storage/engine"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,4 +92,6 @@ CoopGallery213::Application.configure do
     },
     :s3_region => ENV['AWS_REGION']
   }
+
+  config.active_storage.service = :amazon
 end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,14 @@
+local:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+test:
+  service: Disk
+  root: <%= Rails.root.join("tmp/storage") %>
+
+amazon:
+  service: S3
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  bucket: <%= ENV['S3_BUCKET_NAME'] %>
+  region: <%= ENV['AWS_REGION'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>

--- a/db/migrate/20191127202904_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20191127202904_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20191127205244_convert_to_active_storage.rb
+++ b/db/migrate/20191127205244_convert_to_active_storage.rb
@@ -81,7 +81,7 @@ class ConvertToActiveStorage < ActiveRecord::Migration[5.2]
   end
 
   def checksum(attachment)
-    url = attachment.path
-    Digest::MD5.base64digest(File.read(url))
+    url = attachment.url
+    Digest::MD5.base64digest(Net::HTTP.get(URI(url)))
   end
 end

--- a/db/migrate/20191127205244_convert_to_active_storage.rb
+++ b/db/migrate/20191127205244_convert_to_active_storage.rb
@@ -1,0 +1,87 @@
+class ConvertToActiveStorage < ActiveRecord::Migration[5.2]
+  require 'open-uri'
+
+  def up
+    ActiveRecord::Base.connection.raw_connection.prepare("active_storage_blob_statement", <<-SQL)
+      INSERT INTO active_storage_blobs (
+        key, filename, content_type, metadata, byte_size, checksum, created_at
+      ) VALUES ($1, $2, $3, '{}', $4, $5, $6)
+    SQL
+
+    ActiveRecord::Base.connection.raw_connection.prepare("active_storage_attachment_statement", <<-SQL)
+      INSERT INTO active_storage_attachments (
+        name, record_type, record_id, blob_id, created_at
+      ) VALUES ($1, $2, $3, $4, $5)
+    SQL
+
+    Rails.application.eager_load!
+    models = ActiveRecord::Base.descendants.reject(&:abstract_class?)
+
+    transaction do
+      models.each do |model|
+        attachments = model.column_names.map do |c|
+          if c =~ /(.+)_file_name$/
+            $1
+          end
+        end.compact
+
+        if attachments.blank?
+          next
+        end
+
+        model.find_each.each do |instance|
+          attachments.each do |attachment|
+            if instance.send(attachment).path.blank?
+              next
+            end
+
+            make_active_storage_records(instance, attachment, model)
+          end
+        end
+      end
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+
+  private
+
+  def make_active_storage_records(instance, attachment, model)
+    blob_key = key()
+    filename = instance.send("#{attachment}_file_name")
+    content_type = instance.send("#{attachment}_content_type")
+    file_size = instance.send("#{attachment}_file_size")
+    file_checksum = checksum(instance.send(attachment))
+    created_at = instance.updated_at.iso8601
+
+    blob_values = [blob_key, filename, content_type, file_size, file_checksum, created_at]
+
+    ActiveRecord::Base.connection.raw_connection.exec_prepared(
+      "active_storage_blob_statement",
+      blob_values
+    )
+
+    last_blob_id = ActiveStorage::Blob.last.id
+
+    blob_name = attachment
+    record_type = model.name
+    record_id = instance.id
+
+    attachment_values = [blob_name, record_type, record_id, last_blob_id, created_at]
+    ActiveRecord::Base.connection.raw_connection.exec_prepared(
+      "active_storage_attachment_statement",
+      attachment_values
+    )
+  end
+
+  def key
+    SecureRandom.uuid
+  end
+
+  def checksum(attachment)
+    url = attachment.path
+    Digest::MD5.base64digest(File.read(url))
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,31 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_17_171348) do
+ActiveRecord::Schema.define(version: 2019_11_27_205244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "announcements", id: :serial, force: :cascade do |t|
     t.string "title"
@@ -121,5 +142,6 @@ ActiveRecord::Schema.define(version: 2019_02_17_171348) do
     t.index ["slug"], name: "index_users_on_slug"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "users", "artworks", column: "primary_artwork_id", on_delete: :nullify
 end


### PR DESCRIPTION
Starts the migration from paperclip to active storage.

This step:
- Configures active storage
- Completes database migration to copy all existing attachments to the new style.